### PR TITLE
Reduce operators watch scope via downward api env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,17 @@ cd ostia
 oc create -f ostia-operator/deploy/crd.yaml
 ```
 
-* Add cluster-admin perms to the ostia default user: (needs fix)
+* Deploy the operator into the namespace where you wish to manage your API:
 
 ```
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:ostia:default
+oc new-project my-hello-api
+oc create -f ostia-operator/deploy/operator.yaml
 ```
 
-* Deploy the operator, you can create a new project for if:
+* Within the same namespace as the operator, deploy the example Custom Resource:
 
 ```
-oc new-project ostia
-oc create -f ostia-operator/deploy/operator.yml
-```
-
-* Deploy the example Custom Resource in any namespace:
-
-```
-oc new-project myhelloapi
-oc create -f ostia-operator/deploy/cr.yaml
+oc create -f ostia-operator/deploy/cr.yaml -n my-hello-api
 ```
 
 ## Build

--- a/ostia-operator/cmd/ostia-operator/main.go
+++ b/ostia-operator/cmd/ostia-operator/main.go
@@ -27,7 +27,7 @@ func printInfo(namespace string) {
 }
 
 func main() {
-	namespace := os.Getenv("NAMESPACE")
+	namespace := os.Getenv("WATCH_NAMESPACE")
 	printVersion()
 	printInfo(namespace)
 	sdk.Watch("ostia.3scale.net/v1alpha1", "API", namespace, 5)

--- a/ostia-operator/deploy/operator.yaml
+++ b/ostia-operator/deploy/operator.yaml
@@ -14,7 +14,17 @@ spec:
     spec:
       containers:
         - name: ostia-operator
-          image: quay.io/3scale/ostia-operator:v0.1
+          image: quay.io/3scale/ostia-operator:master
+          ports:
+          - containerPort: 60000
+            name: metrics
           command:
           - ostia-operator
           imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "ostia-operator"


### PR DESCRIPTION
After evaluating the [CoreOS operator docs](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/philosophy.md), it appears it would be preferred to deploy an operator per namespace and have the operator manage the crd in that namespace only.

The operator-sdk cli now generates yaml with an env var populated via downward api by default

@jmprusi 