### PR TITLE
Conditional based rate limits

### DIFF
--- a/ostia-operator/pkg/apicast/apicast.go
+++ b/ostia-operator/pkg/apicast/apicast.go
@@ -171,11 +171,15 @@ func createConfig(api *v1alpha1.API) (string, error) {
 
 	apicastHosts = append(apicastHosts, apicastName(api))
 	upStreamPolicy := PolicyChain{"apicast.policy.upstream", PolicyChainConfiguration{Rules: &apicastRules}}
-	rateLimits, err := processRateLimitPolicies(api.Spec.RateLimits)
-	if err != nil {
-		return config, err
+	pc := []PolicyChain{upStreamPolicy}
+
+	if len(api.Spec.RateLimits) > 0 {
+		rateLimits, err := processRateLimitPolicies(api.Spec.RateLimits)
+		if err != nil {
+			return config, err
+		}
+		pc = append(pc, rateLimits)
 	}
-	pc := []PolicyChain{upStreamPolicy, rateLimits}
 
 	apicastConfig := &Config{
 		Services: []Services{

--- a/ostia-operator/pkg/apicast/rate_limit.go
+++ b/ostia-operator/pkg/apicast/rate_limit.go
@@ -65,10 +65,12 @@ func toFixedWindow(rl v1alpha1.RateLimit) (FixedWindowRateLimiter, error) {
 	}
 
 	fw := FixedWindowRateLimiter{
-		Count:  count,
-		Key:    parseLimiterKey(rl),
-		Window: window,
+		Condition: rl.Conditions,
+		Count:     count,
+		Key:       parseLimiterKey(rl),
+		Window:    window,
 	}
+
 	return fw, nil
 }
 
@@ -86,7 +88,7 @@ func toLeakyBucket(rl v1alpha1.RateLimit) (LeakyBucketRateLimiter, error) {
 		burst = *rl.Burst
 	}
 
-	return LeakyBucketRateLimiter{burst, parseLimiterKey(rl), rate / seconds}, nil
+	return LeakyBucketRateLimiter{burst, rl.Conditions, parseLimiterKey(rl), rate / seconds}, nil
 }
 
 func toConnectionBased(rl v1alpha1.RateLimit) (ConnectionRateLimiter, error) {
@@ -109,7 +111,7 @@ func toConnectionBased(rl v1alpha1.RateLimit) (ConnectionRateLimiter, error) {
 		delay = *rl.Delay
 	}
 
-	return ConnectionRateLimiter{burst, conn, delay, parseLimiterKey(rl)}, nil
+	return ConnectionRateLimiter{burst, rl.Conditions, conn, delay, parseLimiterKey(rl)}, nil
 }
 
 func parseTimeLimits(rl v1alpha1.RateLimit) (int, int, error) {
@@ -120,7 +122,7 @@ func parseTimeLimits(rl v1alpha1.RateLimit) (int, int, error) {
 	seconds = 1
 	parsedLimitVal := strings.Split(rl.Limit, "/")
 	requests, err := strconv.Atoi(parsedLimitVal[0])
-	if err != nil || requests < 0 {
+	if err != nil || requests < 1 {
 		return requests, seconds, fmt.Errorf("'limit' value  for %s must be a non-negative integer", rl.Limit)
 	}
 

--- a/ostia-operator/pkg/apicast/rate_limit_test.go
+++ b/ostia-operator/pkg/apicast/rate_limit_test.go
@@ -17,7 +17,7 @@ func TestProcessRateLimits(t *testing.T) {
 		var rl v1alpha1.RateLimit
 		err := json.Unmarshal(rlCrd, &rl)
 		if err != nil {
-			t.Errorf("error unmarshalling rate limit crd snippet to RateLimit struct")
+			t.Fatalf("error unmarshalling rate limit crd snippet to RateLimit struct - %s", err)
 		}
 		return processRateLimitPolicies([]v1alpha1.RateLimit{rl})
 	}
@@ -25,7 +25,7 @@ func TestProcessRateLimits(t *testing.T) {
 	apiCastConfigFromPolicy := func(pc PolicyChain) []byte {
 		conf, err := json.Marshal(pc)
 		if err != nil {
-			t.Errorf("error unmarshalling apicast config")
+			t.Fatalf("error unmarshalling apicast config")
 		}
 		return conf
 	}

--- a/ostia-operator/pkg/apicast/reconcile.go
+++ b/ostia-operator/pkg/apicast/reconcile.go
@@ -38,7 +38,12 @@ func Reconcile(api *v1alpha1.API) (err error) {
 
 func reconcileDeploymentConfig(api *v1alpha1.API) (err error) {
 
-	existingDc, _ := DeploymentConfig(api)
+	existingDc, err := DeploymentConfig(api)
+	if err != nil {
+		log.Errorf(err.Error())
+		return err
+	}
+
 	desiredDc, err := DeploymentConfig(api)
 	if err != nil {
 		log.Errorf(err.Error())

--- a/ostia-operator/pkg/apicast/types.go
+++ b/ostia-operator/pkg/apicast/types.go
@@ -1,8 +1,10 @@
 package apicast
 
+import "github.com/3scale/ostia/ostia-operator/pkg/apis/ostia/v1alpha1"
+
 const (
 	apicastImage   = "quay.io/3scale/apicast"
-	apicastVersion = "master"
+	apicastVersion = "3.3-stable"
 )
 
 // Config is the configuration for APIcast
@@ -47,9 +49,10 @@ type PolicyChainRule struct {
 // Based on a fixed window of time (last X seconds).
 // Can make up to Count requests per Window seconds.
 type FixedWindowRateLimiter struct {
-	Count  int        `json:"count"`
-	Key    LimiterKey `json:"key"`
-	Window int        `json:"window"`
+	Condition *v1alpha1.Condition `json:"condition,omitempty"`
+	Count     int                 `json:"count"`
+	Key       LimiterKey          `json:"key"`
+	Window    int                 `json:"window"`
 }
 
 //LeakyBucketRateLimiter defines a leaky bucket rate limiting rule
@@ -58,9 +61,10 @@ type FixedWindowRateLimiter struct {
 // It allows exceeding that number by Burst requests per second
 // An artificial delay is introduced for those requests between rate and burst to avoid going over the limits.
 type LeakyBucketRateLimiter struct {
-	Burst int        `json:"burst"`
-	Key   LimiterKey `json:"key"`
-	Rate  int        `json:"rate"`
+	Burst     int                 `json:"burst"`
+	Condition *v1alpha1.Condition `json:"condition,omitempty"`
+	Key       LimiterKey          `json:"key"`
+	Rate      int                 `json:"rate"`
 }
 
 //ConnectionRateLimiter defines a connection rate, rate limiting rule
@@ -69,10 +73,11 @@ type LeakyBucketRateLimiter struct {
 // It allows exceeding that number by Burst connections per second.
 // Delay is the number of seconds to delay the connections that exceed the limit.
 type ConnectionRateLimiter struct {
-	Burst int        `json:"burst"`
-	Conn  int        `json:"conn"`
-	Delay int        `json:"delay"`
-	Key   LimiterKey `json:"key"`
+	Burst     int                 `json:"burst"`
+	Condition *v1alpha1.Condition `json:"condition,omitempty"`
+	Conn      int                 `json:"conn"`
+	Delay     int                 `json:"delay"`
+	Key       LimiterKey          `json:"key"`
 }
 
 //LimiterKey defines a structure for rate limiting rules - name must be unique within scope
@@ -80,4 +85,10 @@ type LimiterKey struct {
 	Name     string `json:"name"`
 	NameType string `json:"name_type"`
 	Scope    string `json:"scope"`
+}
+
+//LimiterCondition holds a set of conditions on which a limit will be applied
+// assuming that the operations encapsulated by the condition holds true
+type LimiterCondition struct {
+	Operations v1alpha1.Condition `json:"operations,omitempty"`
 }

--- a/ostia-operator/pkg/apis/ostia/v1alpha1/serialize.go
+++ b/ostia-operator/pkg/apis/ostia/v1alpha1/serialize.go
@@ -1,0 +1,183 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (hc headerBasedCondition) MarshalJSON() ([]byte, error) {
+	var op string
+	if hc.Header == "" || hc.Value == "" {
+		return nil, errors.New("header and header value required for header based condition")
+	}
+
+	op, err := parseOp(hc.Operation)
+	if err != nil {
+		return nil, err
+	}
+
+	condition := make(map[string]string)
+	condition["left"] = fmt.Sprintf("{{headers['%s']}}", hc.Header)
+	condition["left_type"] = "liquid"
+	condition["op"] = op
+	condition["right"] = hc.Value
+
+	b, err := json.Marshal(condition)
+	if err != nil {
+		return nil, errors.New("error marshalling condition")
+	}
+
+	return b, nil
+}
+
+func (mc methodBasedCondition) MarshalJSON() ([]byte, error) {
+	op, err := parseOp(mc.Operation)
+	if err != nil {
+		return nil, err
+	}
+
+	method := strings.ToUpper(mc.Method)
+	switch method {
+	case http.MethodGet, http.MethodPatch, http.MethodPost, http.MethodDelete, http.MethodPut:
+		break
+	default:
+		return nil, errors.New("unsupported http method")
+
+	}
+
+	condition := make(map[string]string)
+	condition["left"] = "{{http_method}}"
+	condition["left_type"] = "liquid"
+	condition["op"] = op
+	condition["right"] = method
+
+	b, err := json.Marshal(condition)
+	if err != nil {
+		return nil, errors.New("error marshalling condition")
+	}
+
+	return b, nil
+}
+
+func (pc pathBasedCondition) MarshalJSON() ([]byte, error) {
+	var op string
+	condition := make(map[string]string)
+
+	if _, err := url.Parse("http://valid.com" + pc.Path); err != nil || pc.Path == "" {
+		return nil, errors.New("invalid path provided")
+	}
+
+	op, err := parseOp(pc.Operation)
+	if err != nil {
+		return nil, err
+	}
+
+	condition["left"] = "{{uri}}"
+	condition["left_type"] = "liquid"
+	condition["op"] = op
+	condition["right"] = pc.Path
+
+	b, err := json.Marshal(condition)
+	if err != nil {
+		return nil, errors.New("error marshalling condition")
+	}
+
+	return b, nil
+}
+
+// UnmarshalJSON is responsible for converting rate limits read via CRD
+// to concrete types which implement the RateLimitCondition interface
+func (c *Condition) UnmarshalJSON(b []byte) error {
+	var raw map[string]json.RawMessage
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return fmt.Errorf("error parsing rate limit conditions - %s", err)
+	}
+
+	var operationsErr error
+	if operations, ok := raw["operations"]; ok {
+		operationsErr = c.setOperations(operations)
+	} else {
+		operationsErr = errors.New("operations required for rate limit conditions")
+	}
+
+	if operationsErr != nil {
+		return operationsErr
+	}
+
+	if len(c.Operations) > 1 {
+		operationErr := errors.New("conditional operator must be set")
+		if operator, ok := raw["operation"]; ok {
+			operationErr = json.Unmarshal(operator, &c.Operator)
+
+		}
+		if operationsErr != nil || c.Operator == "" {
+			return operationErr
+		}
+
+	}
+
+	return nil
+
+}
+
+func (c *Condition) setOperations(b json.RawMessage) error {
+	var operations []json.RawMessage
+
+	err := json.Unmarshal(b, &operations)
+	if err != nil {
+		return err
+	}
+
+	for _, op := range operations {
+		var condition map[string]json.RawMessage
+		err := json.Unmarshal(op, &condition)
+		if err != nil {
+			return err
+		}
+
+		conditionErr := errors.New("unknown condition")
+
+		if _, ok := condition["header"]; ok {
+			var h headerBasedCondition
+			conditionErr = json.Unmarshal(op, &h)
+			c.Operations = append(c.Operations, h)
+
+		} else if _, ok := condition["http_method"]; ok {
+			var hm methodBasedCondition
+			conditionErr = json.Unmarshal(op, &hm)
+			c.Operations = append(c.Operations, hm)
+
+		} else if _, ok := condition["request_path"]; ok {
+			var rp pathBasedCondition
+			conditionErr = json.Unmarshal(op, &rp)
+			c.Operations = append(c.Operations, rp)
+
+		}
+
+		if conditionErr != nil {
+			return fmt.Errorf("error calling unmarshal - %s ", conditionErr)
+		}
+
+	}
+	return nil
+
+}
+
+func parseOp(op string) (string, error) {
+	if op != "" {
+		switch op {
+		case "==", "!=":
+			break
+		default:
+			return "", errors.New("unrecognised operand provided")
+		}
+	} else {
+		op = "=="
+	}
+	return op, nil
+}

--- a/ostia-operator/pkg/apis/ostia/v1alpha1/serialize_test.go
+++ b/ostia-operator/pkg/apis/ostia/v1alpha1/serialize_test.go
@@ -1,0 +1,149 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshalCondition(t *testing.T) {
+	inputs := []struct {
+		crd       []byte
+		expectC   *Condition
+		expectErr bool
+	}{
+		{
+			crd: []byte(`{"operation":"and", "operations":[{"http_method": "GET"}]}`),
+			expectC: &Condition{
+				Operator: "",
+				Operations: []RateLimitCondition{
+					methodBasedCondition{Method: "GET"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			crd: []byte(`{"operation":"or", "operations":[{"http_method": "GET"}]}`),
+			expectC: &Condition{
+				Operator: "",
+				Operations: []RateLimitCondition{
+					methodBasedCondition{Method: "GET"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			crd: []byte(`{"operation":"or", "operations":[{"http_method": "GET"},{"request_path":"/test", "op":"!="}]}`),
+			expectC: &Condition{
+				Operator: "or",
+				Operations: []RateLimitCondition{
+					methodBasedCondition{Method: "GET"},
+					pathBasedCondition{Path: "/test", Operation: "!="},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			crd: []byte(`{"operation":"and", "operations":[{"http_method": "GET"},{"request_path":"/test", "op":"!="},{"header": "TEST", "value":"test"}]}`),
+			expectC: &Condition{
+				Operator: "and",
+				Operations: []RateLimitCondition{
+					methodBasedCondition{Method: "GET"},
+					pathBasedCondition{Path: "/test", Operation: "!="},
+					headerBasedCondition{Header: "TEST", Value: "test"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			crd:       []byte(`{"operation":"and", "operations":[{"httP_method": "GET"}]}`),
+			expectErr: true,
+		},
+		{
+			crd:       []byte(`{"operations":[{"http_method": "GET"},{"request_path":"/test", "op":"!="}]}`),
+			expectErr: true,
+		},
+	}
+	for _, input := range inputs {
+		c := &Condition{}
+		err := c.UnmarshalJSON(input.crd)
+
+		if input.expectErr && err != nil {
+			continue
+		} else if err != nil {
+			t.Errorf("unexpected error")
+		}
+
+		if !reflect.DeepEqual(input.expectC, c) {
+			fmt.Println(string(input.crd))
+			t.Fatalf("unexpected condition parsed")
+		}
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	inputs := []struct {
+		obj            RateLimitCondition
+		expectContents string
+		expectErr      bool
+	}{
+		{
+			obj:            pathBasedCondition{Path: "/test_default_eq"},
+			expectContents: `{"left":"{{uri}}","left_type":"liquid","op":"==","right":"/test_default_eq"}`,
+		},
+		{
+			obj:            pathBasedCondition{Path: "/test_default_eq", Operation: "!="},
+			expectContents: `{"left":"{{uri}}","left_type":"liquid","op":"!=","right":"/test_default_eq"}`,
+		},
+		{
+			obj:       pathBasedCondition{Path: "/test_default_eq", Operation: "invalid"},
+			expectErr: true,
+		},
+		{
+			obj:       pathBasedCondition{Path: "/invalid*", Operation: "invalid"},
+			expectErr: true,
+		},
+		{
+			obj:       pathBasedCondition{Path: "\bad_path*"},
+			expectErr: true,
+		},
+		{
+			obj:            headerBasedCondition{Header: "test", Value: "example"},
+			expectContents: `{"left":"{{headers['test']}}","left_type":"liquid","op":"==","right":"example"}`,
+		},
+		{
+			obj:       headerBasedCondition{Header: "", Value: "example"},
+			expectErr: true,
+		},
+		{
+			obj:       headerBasedCondition{Header: "test", Value: ""},
+			expectErr: true,
+		},
+		{
+			obj:            methodBasedCondition{Method: "GET"},
+			expectContents: `{"left":"{{http_method}}","left_type":"liquid","op":"==","right":"GET"}`,
+		},
+		{
+			obj:            methodBasedCondition{Method: "get"},
+			expectContents: `{"left":"{{http_method}}","left_type":"liquid","op":"==","right":"GET"}`,
+		},
+		{
+			obj:       methodBasedCondition{Method: "INVALID"},
+			expectErr: true,
+		},
+	}
+
+	for _, input := range inputs {
+		res, err := input.obj.MarshalJSON()
+		if input.expectErr && err != nil {
+			continue
+		} else if err != nil {
+			t.Errorf("unexpected error")
+		}
+		if !strings.Contains(string(res), input.expectContents) {
+			t.Errorf("unexpected or missing config - \nshould contain - %s \nequals -%s",
+				input.expectContents, string(res))
+		}
+	}
+}

--- a/ostia-operator/pkg/apis/ostia/v1alpha1/types.go
+++ b/ostia-operator/pkg/apis/ostia/v1alpha1/types.go
@@ -46,11 +46,39 @@ type Endpoint struct {
 
 // RateLimit is a struct used to define different types of rate limiting rules
 type RateLimit struct {
-	Burst  *int   `json:"burst"`
-	Conn   *int   `json:"conn"`
-	Delay  *int   `json:"delay"`
-	Limit  string `json:"limit"`
-	Name   string `json:"name"`   //TODO - This needs to reference and endpoint name currently but this relationship will reverse.
-	Source string `json:"source"` // Source will allow user to limit based on jwt, source ip etc
-	Type   string `json:"type"`
+	Burst      *int       `json:"burst"`
+	Conn       *int       `json:"conn"`
+	Delay      *int       `json:"delay"`
+	Limit      string     `json:"limit"`
+	Name       string     `json:"name"`   //TODO - This needs to reference and endpoint name currently but this relationship will reverse.
+	Source     string     `json:"source"` // Source will allow user to limit based on jwt, source ip etc
+	Type       string     `json:"type"`
+	Conditions *Condition `json:"conditions, omitempty"`
+}
+
+// Condition wraps a generic rate limit condition
+type Condition struct {
+	Operator   string               `json:"operator,omitempty"`
+	Operations []RateLimitCondition `json:"operations"`
+}
+
+// RateLimitCondition is an interface for a type which should marshal to apicast config
+type RateLimitCondition interface {
+	MarshalJSON() ([]byte, error)
+}
+
+type headerBasedCondition struct {
+	Header    string `json:"header"`
+	Operation string `json:"op, omitempty"`
+	Value     string `json:"value"`
+}
+
+type methodBasedCondition struct {
+	Method    string `json:"http_method"`
+	Operation string `json:"op, omitempty"`
+}
+
+type pathBasedCondition struct {
+	Path      string `json:"request_path,omitempty"`
+	Operation string `json:"op, omitempty"`
 }

--- a/ostia-operator/test/tests/03-rate-limit/fixed_rate_header_condition.yaml
+++ b/ostia-operator/test/tests/03-rate-limit/fixed_rate_header_condition.yaml
@@ -1,0 +1,13 @@
+apiVersion: "ostia.3scale.net/v1alpha1"
+kind: "API"
+metadata:
+  name: "endpoints"
+spec:
+  rate_limits:
+  - type: FixedWindow
+    name: fixed
+    limit: 5/m
+    conditions:
+      operations:
+      - header: "Deny"
+        value: "test"

--- a/ostia-operator/test/tests/03-rate-limit/fixed_rate_http_method_condition.yaml
+++ b/ostia-operator/test/tests/03-rate-limit/fixed_rate_http_method_condition.yaml
@@ -1,0 +1,12 @@
+apiVersion: "ostia.3scale.net/v1alpha1"
+kind: "API"
+metadata:
+  name: "endpoints"
+spec:
+  rate_limits:
+  - type: FixedWindow
+    name: fixed
+    limit: 10/m
+    conditions:
+      operations:
+      - http_method: "GET"

--- a/ostia-operator/test/tests/03-rate-limit/fixed_rate_path_condition.yaml
+++ b/ostia-operator/test/tests/03-rate-limit/fixed_rate_path_condition.yaml
@@ -1,0 +1,12 @@
+apiVersion: "ostia.3scale.net/v1alpha1"
+kind: "API"
+metadata:
+  name: "endpoints"
+spec:
+  rate_limits:
+  - type: FixedWindow
+    name: fixed
+    limit: 10/m
+    conditions:
+      operations:
+      - request_path: "/restrict"

--- a/ostia-operator/test/tests/03-rate-limit/run.sh
+++ b/ostia-operator/test/tests/03-rate-limit/run.sh
@@ -46,5 +46,54 @@ if [[ ${fixed_rate_exec_ip} != *"10 200"*"10 429"* ]]; then
 fi
 echo "IP based rate limiting in namespace ${ns} success"
 
+
+echo "Testing fixed rate path based limiting in namespace ${ns}"
+oc apply -f ./fixed_rate_path_condition.yaml -n ${ns} &> /dev/null
+wait_for_pod_ready app apicast ${ns}
+fixed_rate_path_success=$(do_http_get ${host}"/allow" 20)
+if [[ ${fixed_rate_path_success} != *"20 200"* ]]; then
+    fail ${fixed_rate_path_success}
+fi
+
+fixed_rate_path_deny=$(do_http_get ${host}"/restrict" 20)
+if [[ ${fixed_rate_path_deny} != *"10 200"*"10 429"* ]]; then
+    fail ${fixed_rate_path_deny}
+fi
+
+path_success_retry=$(do_http_get ${host}"/allow" 20)
+if [[ ${path_success_retry} != *"20 200"* ]]; then
+    fail ${path_success_retry}
+fi
+echo "Path based rate limiting in namespace ${ns} success"
+
+echo "Testing fixed rate header based limiting in namespace ${ns}"
+oc apply -f ./fixed_rate_header_condition.yaml -n ${ns} &> /dev/null
+wait_for_pod_ready app apicast ${ns}
+fixed_rate_header_deny=$(do_http_get ${host}"/" 10 "Deny: test")
+if [[ ${fixed_rate_header_deny} != *"5 200"*"5 429"* ]]; then
+    fail ${fixed_rate_header_deny}
+fi
+
+fixed_rate_header_allow=$(do_http_get ${host}"/" 10 "Deny: test-ignore")
+if [[ ${fixed_rate_header_allow} != *"10 200"* ]]; then
+    fail ${fixed_rate_header_allow}
+fi
+echo "Header based rate limiting in namespace ${ns} success"
+
+
+echo "Testing fixed rate http method based limiting in namespace ${ns}"
+oc apply -f ./fixed_rate_http_method_condition.yaml -n ${ns} &> /dev/null
+wait_for_pod_ready app apicast ${ns}
+fixed_rate_get_deny=$(do_http_get ${host}"/" 20)
+if [[ ${fixed_rate_get_deny} != *"10 200"*"10 429"* ]]; then
+    fail ${fixed_rate_get_deny}
+fi
+
+fixed_rate_post_allow=$(do_http_post ${host}"/" 20)
+if [[ ${fixed_rate_post_allow} != *"20 200"* ]]; then
+    fail ${fixed_rate_post_allow}
+fi
+echo "HTTP method based rate limiting in namespace ${ns} success"
+
 label_namespace ${ns} "ostia-test-result=success"
 echo -e "Endpoint test successful in ${ns}\n"

--- a/ostia-operator/test/tests/common/common.sh
+++ b/ostia-operator/test/tests/common/common.sh
@@ -71,9 +71,20 @@ wait_for_pod_ready () {
 
 # Prints to stdout the number of each unique status codes
 # Expects two args: Endpoint to make HTTP request against, number of requests to make
+# Optional third arg: Header as string
 do_http_get() {
  for i in $(seq 1 ${2}); do
-   curl -k -s -o /dev/null -w "%{http_code}\n" ${1}
+   curl -k -s -o /dev/null -w "%{http_code}\n" -H "${3}" --url ${1}
+ done | uniq -c
+
+}
+
+# Prints to stdout the number of each unique status codes
+# Expects two args: Endpoint to make HTTP request against, number of requests to make
+# Optional third arg: Header as string
+do_http_post() {
+ for i in $(seq 1 ${2}); do
+   curl -k -s -o /dev/null -w "%{http_code}\n" -X POST -H "${3}" --url ${1}
  done | uniq -c
 
 }


### PR DESCRIPTION
This implements both header based and path based rate limiting using conditionals within the apicast rate limit policy. Users can define conditions as examples below within crd rate limits. Default operation if not provided is `==`:

### Path Based
```yaml
---
type: FixedWindow
name: fixed
limit: 10/s
conditions:
   operations:
   - request_path: "/example"
      op: "!="
```

### Header Based
```yaml
---
type: FixedWindow
name: fixed
limit: 10/s
conditions:
   operations:
   - header: Example
      value: eg
```

### HTTP Method Based
```
type: FixedWindow
name: fixed
limit: 10/m
conditions:
   operations:
   - http_method: GET
```

### Multiple Conditions
```
type: FixedWindow
name: fixed
limit: 10/m
conditions:
   operation: or
   operations:
   - http_method: GET
   - header: Example
      value: eg
      op: "!="
```