### PR TITLE
Add creation for non existent services

### DIFF
--- a/threescaleAPI-operator/pkg/threescale/system_client/services.go
+++ b/threescaleAPI-operator/pkg/threescale/system_client/services.go
@@ -20,6 +20,7 @@ func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Servi
 	values := url.Values{}
 	values.Add("access_token", accessToken)
 	values.Add("name", name)
+	values.Add("system_name", name)
 
 	body := strings.NewReader(values.Encode())
 	req, err := c.buildPostReq(endpoint, body)

--- a/threescaleAPI-operator/pkg/threescaleAPI/handler.go
+++ b/threescaleAPI-operator/pkg/threescaleAPI/handler.go
@@ -45,71 +45,86 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 			panic(err)
 		}
 
-		systemAdminPortalURL, _ := url.Parse(o.Spec.The3ScaleConfig.AdminPortalURL)
+		c, err := createClientFromCrd(o)
+		if err != nil {
+			panic("error creating required client for 3scale system")
+		}
+
 		accessToken := o.Spec.The3ScaleConfig.AccessToken
 		serviceName := o.Name
-		port := 0
-		if systemAdminPortalURL.Port() == "" {
-			switch scheme := systemAdminPortalURL.Scheme; scheme {
-			case "http":
-				port = 80
-			case "https":
-				port = 443
+
+		service, err := ensureServiceExists(c, accessToken, serviceName)
+		if err != nil {
+			return fmt.Errorf("error synchronizing service state - %s", err.Error())
+
+		}
+
+		existingEndpoints, err := getEndpointsFrom3scaleSystem(c, accessToken, service)
+		if err != nil {
+			fmt.Printf("Couldn't get Endpoints from 3scale: %v\n", err)
+
+		}
+
+		existingPlans, err := getPlansFrom3scaleSystem(c, accessToken, service)
+
+		if !compareEndpoints(desiredEndpoints, existingEndpoints) {
+			fmt.Println("[!] Endpoints are not in sync.")
+			err := reconcileEndpointsWith3scaleSystem(c, accessToken, service, existingEndpoints, desiredEndpoints)
+			if err != nil {
+				panic("something went wrong")
 			}
 		} else {
-			port, err = strconv.Atoi(systemAdminPortalURL.Port())
-			if err != nil {
-				fmt.Printf("Admin Portal URL invalid port: %v\n", err)
-			}
-		}
-		adminPortal, err := client.NewAdminPortal(systemAdminPortalURL.Scheme, systemAdminPortalURL.Host, port)
-
-		if err != nil {
-			fmt.Printf("Invalid Admin Portal URL: %v\n", err)
+			fmt.Println("[=] Endpoints are in sync. Nothing to do.")
 		}
 
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		insecureHttp := &http.Client{Transport: tr}
-
-		c := client.NewThreeScale(adminPortal, insecureHttp)
-
-		service, err := getServiceFromServiceSystemName(c, accessToken, serviceName)
-		if err != nil {
-			fmt.Printf("Service Name: %v not found: %v \n", o.Name, err)
+		if !comparePlans(desiredPlans, existingPlans) {
+			fmt.Println("[!] Plans are not in Sync")
+			reconcilePlansAndLimits(c, service, accessToken, desiredPlans)
 
 		} else {
+			fmt.Println("[=] Plans are in sync. Nothing to do.")
+		}
 
-			existingEndpoints, err := getEndpointsFrom3scaleSystem(c, accessToken, service)
-			if err != nil {
-				fmt.Printf("Couldn't get Endpoints from 3scale: %v\n", err)
+		fmt.Println("Run done.")
 
-			}
+	}
 
-			existingPlans, err := getPlansFrom3scaleSystem(c, accessToken, service)
+	return nil
+}
 
-			if !compareEndpoints(desiredEndpoints, existingEndpoints) {
-				fmt.Println("[!] Endpoints are not in sync.")
-				err := reconcileEndpointsWith3scaleSystem(c, accessToken, service, existingEndpoints, desiredEndpoints)
-				if err != nil {
-					panic("something went wrong")
-				}
-			} else {
-				fmt.Println("[=] Endpoints are in sync. Nothing to do.")
-			}
+func createClientFromCrd(api *v1alpha1.API) (*client.ThreeScaleClient, error) {
+	systemAdminPortalURL, err := url.Parse(api.Spec.The3ScaleConfig.AdminPortalURL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing 3scale url from crd - %s", err.Error())
+	}
 
-			if !comparePlans(desiredPlans, existingPlans) {
-				fmt.Println("[!] Plans are not in Sync")
-				reconcilePlansAndLimits(c, service, accessToken, desiredPlans)
-
-			} else {
-				fmt.Println("[=] Plans are in sync. Nothing to do.")
-			}
-
-			fmt.Println("Run done.")
-
+	port := 0
+	if systemAdminPortalURL.Port() == "" {
+		switch scheme := systemAdminPortalURL.Scheme; scheme {
+		case "http":
+			port = 80
+		case "https":
+			port = 443
+		}
+	} else {
+		port, err = strconv.Atoi(systemAdminPortalURL.Port())
+		if err != nil {
+			return nil, fmt.Errorf("admin portal URL invalid port - %s" + err.Error())
 		}
 	}
-	return nil
+
+	adminPortal, err := client.NewAdminPortal(systemAdminPortalURL.Scheme, systemAdminPortalURL.Host, port)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Admin Portal URL: %s", err.Error())
+	}
+
+	// TODO - This should be secure by default and overrideable for testing
+	// TODO - Set some sensible default here to handle timeouts
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	insecureHttp := &http.Client{Transport: tr}
+
+	c := client.NewThreeScale(adminPortal, insecureHttp)
+	return c, nil
 }

--- a/threescaleAPI-operator/pkg/threescaleAPI/reconciliation.go
+++ b/threescaleAPI-operator/pkg/threescaleAPI/reconciliation.go
@@ -26,6 +26,21 @@ func (ostiaExtensions *ostiaExtensions) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, ostiaExtensions)
 }
 
+// Function which will check for the existence of a service by name and attempt
+// to create it if it does not already exist
+// Return error if unable to read current services from system or unable to create service
+func ensureServiceExists(c *client.ThreeScaleClient, accessToken string, name string) (client.Service, error) {
+	var svc client.Service
+	svc, err := getServiceFromServiceSystemName(c, accessToken, name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			svc, err = c.CreateService(accessToken, name)
+
+		}
+	}
+	return svc, err
+}
+
 func reconcilePlansAndLimits(c *client.ThreeScaleClient, service client.Service, accessToken string, desiredPlans Plans) {
 	var planFetchErr error
 


### PR DESCRIPTION
Takes care of :
- [X] Create service based on CR name if it doesn't exist

Moves the 3scale client parsing and creation into its own function