### PR TITLE
Allow override of proxy image via environment variables

### DIFF
--- a/ostia-operator/pkg/apicast/types.go
+++ b/ostia-operator/pkg/apicast/types.go
@@ -2,11 +2,6 @@ package apicast
 
 import "github.com/3scale/ostia/ostia-operator/pkg/apis/ostia/v1alpha1"
 
-const (
-	apicastImage   = "quay.io/3scale/apicast"
-	apicastVersion = "3.3-stable"
-)
-
 // Config is the configuration for APIcast
 type Config struct {
 	Services []Services `json:"services"`


### PR DESCRIPTION
Change does an initial read of env vars at runtime, allowing the proxy image and tag to be modified via env vars without having to rebuild the operator each time