### PR TITLE
Plans patch

### DIFF
--- a/threescaleAPI-operator/deploy/cr.yaml
+++ b/threescaleAPI-operator/deploy/cr.yaml
@@ -4,8 +4,9 @@ metadata:
   name: merging
 spec: 
   3scaleConfig:
-     AccessToken: XXXXXXXXXXXXXXXXXXXXXXX
-     AdminPortalURL: "https://XXXXX-admin.3scale.net"
+     credentials:
+       access_token: XXXXXXXXXXXXXXXXXXXXXXX
+       admin_portal_url: "https://XXXXX-admin.3scale.net"
      IntegrationMethod: apicast
   upstream: "https://myUnprotectedAPI:80"
   plans:

--- a/threescaleAPI-operator/pkg/threescale/system_client/types.go
+++ b/threescaleAPI-operator/pkg/threescale/system_client/types.go
@@ -104,7 +104,7 @@ type MetricList struct {
 type Plan struct {
 	XMLNameName        xml.Name `xml:"plan"`
 	Custom             string   `xml:"custom,attr"`
-	Default            string   `xml:"default,attr"`
+	Default            bool     `xml:"default,attr"`
 	ID                 string   `xml:"id"`
 	PlanName           string   `xml:"name"`
 	Type               string   `xml:"type"`

--- a/threescaleAPI-operator/pkg/threescaleAPI/handler.go
+++ b/threescaleAPI-operator/pkg/threescaleAPI/handler.go
@@ -99,14 +99,6 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 			existingPlans, err := getPlansFrom3scaleSystem(c, accessToken, service)
 			existingEndpoints, err := getEndpointsFrom3scaleSystem(c, accessToken, service)
 
-			if !comparePlans(desiredPlans, existingPlans) {
-				fmt.Println("[!] Plans are not in Sync")
-				reconcilePlansAndLimits(c, service, accessToken, desiredPlans)
-				if err != nil {
-					fmt.Printf("Couldn't get Endpoints from 3scale: %v\n", err)
-
-				}
-			}
 			if !compareEndpoints(desiredEndpoints, existingEndpoints) {
 				fmt.Println("[!] Endpoints are not in sync.")
 				err := reconcileEndpointsWith3scaleSystem(c, accessToken, service, existingEndpoints, desiredEndpoints)

--- a/threescaleAPI-operator/pkg/threescaleAPI/reconciliation.go
+++ b/threescaleAPI-operator/pkg/threescaleAPI/reconciliation.go
@@ -475,6 +475,7 @@ func getPlansFrom3scaleSystem(c *client.ThreeScaleClient, accessToken string, se
 		limits, _ := c.ListLimitsPerAppPlan(accessToken, v.ID)
 
 		plan.Name = v.PlanName
+		plan.Default = v.Default
 		metrics, _ := c.ListMetrics(accessToken, v.ServiceID)
 		for _, v := range limits.Limits {
 			var limit v1alpha1.Limit


### PR DESCRIPTION
Plans were not syncing with crd due to the default false being set each time. This also updates the custom resource example manifest to include the changes to the credential handling made in #49 