### PR TITLE
[doc] use Brewfile to install dependencies by brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ oc create -f ostia-operator/deploy/cr.yaml -n my-hello-api
 ## Build
 
 * Prerequisites:
-  * Go >= 1.10
+  * Go
   * Go Dep (<https://github.com/golang/dep>)
-  * Operator-SDK v0.0.5 (<https://github.com/operator-framework/operator-sdk>)
+  * Operator-SDK (<https://github.com/operator-framework/operator-sdk>)
   * Docker
+
+* Using homebrew (macOS)
+
+Run `brew bundle` in the project root to install all dependencies by homebrew.
 
 * Installing Go:
 

--- a/ostia-operator/Brewfile
+++ b/ostia-operator/Brewfile
@@ -1,0 +1,2 @@
+brew 'operator-sdk'
+brew 'dep'


### PR DESCRIPTION
`Brewfile` is a way to define a project's dependencies and then just install them by one command `brew bundle`.