### PR TITLE
limitador: add basic error handling

### DIFF
--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"
 redis = "0.16.0"
+thiserror = "1.0"
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/limitador/src/errors.rs
+++ b/limitador/src/errors.rs
@@ -1,0 +1,16 @@
+use crate::storage::StorageErr;
+use thiserror::Error;
+
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum LimitadorError {
+    #[error("error while accessing the limits storage: {0:?}")]
+    Storage(String),
+    #[error("missing namespace")]
+    MissingNamespace,
+}
+
+impl From<StorageErr> for LimitadorError {
+    fn from(e: StorageErr) -> Self {
+        LimitadorError::Storage(e.msg().to_owned())
+    }
+}

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -1,40 +1,14 @@
 use crate::counter::Counter;
+use crate::errors::LimitadorError;
 use crate::limit::Limit;
 use crate::storage::in_memory::InMemoryStorage;
 use crate::storage::Storage;
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
-use std::fmt;
-use std::fmt::{Display, Formatter};
 
 mod counter;
+pub mod errors;
 pub mod limit;
 mod storage;
-
-#[derive(Debug)]
-pub struct MissingNamespaceErr {
-    msg: String,
-}
-
-impl MissingNamespaceErr {
-    fn new() -> MissingNamespaceErr {
-        MissingNamespaceErr {
-            msg: "Missing namespace".to_string(),
-        }
-    }
-}
-
-impl Display for MissingNamespaceErr {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg)
-    }
-}
-
-impl Error for MissingNamespaceErr {
-    fn description(&self) -> &str {
-        &self.msg
-    }
-}
 
 pub struct RateLimiter {
     storage: Box<dyn Storage>,
@@ -47,47 +21,74 @@ impl RateLimiter {
         }
     }
 
-    pub fn add_limit(&mut self, limit: Limit) {
-        self.storage.add_limit(limit);
+    pub fn add_limit(&mut self, limit: Limit) -> Result<(), LimitadorError> {
+        self.storage.add_limit(limit).map_err(|err| err.into())
     }
 
-    pub fn get_limits(&self, namespace: &str) -> HashSet<Limit> {
-        self.storage.get_limits(namespace)
+    pub fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, LimitadorError> {
+        self.storage.get_limits(namespace).map_err(|err| err.into())
     }
 
     pub fn is_rate_limited(
         &self,
         values: &HashMap<String, String>,
-    ) -> Result<bool, MissingNamespaceErr> {
+    ) -> Result<bool, LimitadorError> {
         // TODO: hardcoded delta
 
         match values.get("namespace") {
-            Some(namespace) => Ok(self
-                .get_limits(namespace)
-                .iter()
-                .filter(|lim| lim.applies(values))
-                .map(|lim| Counter::new(lim.clone(), values.clone()))
-                .any(|counter| !self.storage.is_within_limits(&counter, 1))),
-            None => Err(MissingNamespaceErr::new()),
+            Some(namespace) => {
+                let counters = self.counters_that_apply(namespace, values)?;
+
+                for counter in counters {
+                    match self.storage.is_within_limits(&counter, 1) {
+                        Ok(within_limits) => {
+                            if !within_limits {
+                                return Ok(true);
+                            }
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+
+                Ok(false)
+            }
+            None => Err(LimitadorError::MissingNamespace),
         }
     }
 
     pub fn update_counters(
         &mut self,
         values: &HashMap<String, String>,
-    ) -> Result<(), MissingNamespaceErr> {
+    ) -> Result<(), LimitadorError> {
         match values.get("namespace") {
             // TODO: hardcoded delta
             Some(namespace) => {
-                self.get_limits(namespace)
+                let counters = self.counters_that_apply(namespace, values)?;
+
+                counters
                     .iter()
-                    .filter(|lim| lim.applies(values))
-                    .map(|lim| Counter::new(lim.clone(), values.clone()))
-                    .for_each(|counter| self.storage.update_counter(&counter, 1));
-                Ok(())
+                    .try_for_each(|counter| self.storage.update_counter(&counter, 1))
+                    .map_err(|err| err.into())
             }
-            None => Err(MissingNamespaceErr::new()),
+            None => Err(LimitadorError::MissingNamespace),
         }
+    }
+
+    // TODO: return iterator and avoid collect() call
+    fn counters_that_apply(
+        &self,
+        namespace: &str,
+        values: &HashMap<String, String>,
+    ) -> Result<Vec<Counter>, LimitadorError> {
+        let limits = self.get_limits(namespace)?;
+
+        let counters = limits
+            .iter()
+            .filter(|lim| lim.applies(values))
+            .map(|lim| Counter::new(lim.clone(), values.clone()))
+            .collect();
+
+        Ok(counters)
     }
 }
 

--- a/limitador/src/server.rs
+++ b/limitador/src/server.rs
@@ -26,7 +26,7 @@ impl MyRateLimiter {
 
                 let mut rate_limiter = RateLimiter::new();
                 for limit in limits {
-                    rate_limiter.add_limit(limit);
+                    rate_limiter.add_limit(limit).unwrap();
                 }
 
                 MyRateLimiter {

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -1,13 +1,33 @@
 use crate::counter::Counter;
 use crate::limit::Limit;
+use ::redis::RedisError;
 use std::collections::HashSet;
+use thiserror::Error;
 
 pub mod in_memory;
 pub mod redis;
 
 pub trait Storage: Sync + Send {
-    fn add_limit(&mut self, limit: Limit);
-    fn get_limits(&self, namespace: &str) -> HashSet<Limit>;
-    fn is_within_limits(&self, counter: &Counter, delta: i64) -> bool;
-    fn update_counter(&mut self, counter: &Counter, delta: i64);
+    fn add_limit(&mut self, limit: Limit) -> Result<(), StorageErr>;
+    fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, StorageErr>;
+    fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr>;
+    fn update_counter(&mut self, counter: &Counter, delta: i64) -> Result<(), StorageErr>;
+}
+
+#[derive(Error, Debug)]
+#[error("error while accessing the limits storage: {msg}")]
+pub struct StorageErr {
+    msg: String,
+}
+
+impl StorageErr {
+    pub fn msg(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl From<RedisError> for StorageErr {
+    fn from(e: RedisError) -> Self {
+        StorageErr { msg: e.to_string() }
+    }
 }

--- a/limitador/src/storage/redis.rs
+++ b/limitador/src/storage/redis.rs
@@ -3,7 +3,7 @@ extern crate redis;
 use self::redis::Commands;
 use crate::counter::Counter;
 use crate::limit::Limit;
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageErr};
 use std::collections::HashSet;
 use std::iter::FromIterator;
 
@@ -12,9 +12,6 @@ use std::iter::FromIterator;
 
 // TODO: try redis-rs async functions.
 
-// TODO: handle errors in all functions. We'll need to modify the Storage trait
-// so it returns Result.
-
 const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
 
 pub struct RedisStorage {
@@ -22,61 +19,56 @@ pub struct RedisStorage {
 }
 
 impl Storage for RedisStorage {
-    fn add_limit(&mut self, limit: Limit) {
+    fn add_limit(&mut self, limit: Limit) -> Result<(), StorageErr> {
+        let mut con = self.client.get_connection()?;
+
         let set_key = Self::key_for_limits_of_namespace(limit.namespace());
-        let mut con = self.client.get_connection().unwrap();
-        con.sadd::<String, String, u32>(set_key, serde_json::to_string(&limit).unwrap())
-            .unwrap();
+        let serialized_limit = serde_json::to_string(&limit).unwrap();
+
+        con.sadd::<String, String, _>(set_key, serialized_limit)?;
+        Ok(())
     }
 
-    fn get_limits(&self, namespace: &str) -> HashSet<Limit> {
+    fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, StorageErr> {
+        let mut con = self.client.get_connection()?;
+
         let set_key = Self::key_for_limits_of_namespace(namespace);
-        let mut con = self.client.get_connection().unwrap();
-        match con.smembers::<String, HashSet<String>>(set_key) {
-            Ok(result) => {
-                let limits: HashSet<Limit> = HashSet::from_iter(
-                    result
-                        .iter()
-                        .map(|limit_json| serde_json::from_str(limit_json).unwrap()),
-                );
-                limits
-            }
-            _ => HashSet::new(),
+
+        let limits: HashSet<Limit> = HashSet::from_iter(
+            con.smembers::<String, HashSet<String>>(set_key)?
+                .iter()
+                .map(|limit_json| serde_json::from_str(limit_json).unwrap()),
+        );
+
+        Ok(limits)
+    }
+
+    fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr> {
+        let mut con = self.client.get_connection()?;
+
+        match con.get::<String, Option<i64>>(Self::key_for_counter(counter))? {
+            Some(val) => Ok(val - delta >= 0),
+            None => Ok(counter.max_value() - delta >= 0),
         }
     }
 
-    fn is_within_limits(&self, counter: &Counter, delta: i64) -> bool {
-        let mut con = self.client.get_connection().unwrap();
-        match con.get::<String, Option<i64>>(Self::key_for_counter(counter)) {
-            Ok(value) => match value {
-                Some(val) => val - delta >= 0,
-                None => counter.max_value() - delta >= 0,
-            },
-            Err(_) => false,
-        }
-    }
+    fn update_counter(&mut self, counter: &Counter, delta: i64) -> Result<(), StorageErr> {
+        let mut con = self.client.get_connection()?;
 
-    fn update_counter(&mut self, counter: &Counter, delta: i64) {
-        // TODO: this can be simplified. The get command is not needed.
         let counter_key = Self::key_for_counter(counter);
-        let mut con = self.client.get_connection().unwrap();
-        if let Ok(result) = con.get::<String, Option<i64>>(counter_key.clone()) {
-            match result {
-                Some(_) => {
-                    con.incr::<String, i64, i64>(counter_key, -delta).unwrap();
-                }
-                None => {
-                    if con
-                        .set_ex::<String, i64, usize>(
-                            counter_key,
-                            counter.max_value() - delta,
-                            counter.seconds() as usize,
-                        )
-                        .is_ok()
-                    {}
-                }
-            }
-        };
+
+        match con.get::<String, Option<i64>>(counter_key.clone())? {
+            Some(_val) => con
+                .incr::<String, i64, ()>(counter_key, -delta)
+                .map_err(|e| e.into()),
+            None => con
+                .set_ex::<String, i64, ()>(
+                    counter_key,
+                    counter.max_value() - delta,
+                    counter.seconds() as usize,
+                )
+                .map_err(|e| e.into()),
+        }
     }
 }
 
@@ -116,8 +108,8 @@ mod tests {
         let namespace = "test_namespace";
         let mut storage = RedisStorage::default();
         let limit = Limit::new(namespace, 10, 60, vec!["x == 10"], vec!["x"]);
-        storage.add_limit(limit.clone());
-        assert!(storage.get_limits(namespace).contains(&limit))
+        storage.add_limit(limit.clone()).unwrap();
+        assert!(storage.get_limits(namespace).unwrap().contains(&limit))
     }
 
     #[test]
@@ -138,7 +130,7 @@ mod tests {
 
         let mut storage = RedisStorage::default();
 
-        storage.add_limit(limit.clone());
+        storage.add_limit(limit.clone()).unwrap();
 
         let mut values: HashMap<String, String> = HashMap::new();
         values.insert("namespace".to_string(), namespace.to_string());
@@ -148,10 +140,10 @@ mod tests {
         let counter = Counter::new(limit, values);
 
         for _ in 0..max_hits {
-            assert!(storage.is_within_limits(&counter, 1));
-            storage.update_counter(&counter, 1);
+            assert!(storage.is_within_limits(&counter, 1).unwrap());
+            storage.update_counter(&counter, 1).unwrap();
         }
-        assert_eq!(false, storage.is_within_limits(&counter, 1));
+        assert_eq!(false, storage.is_within_limits(&counter, 1).unwrap());
     }
 
     fn clean_db() {


### PR DESCRIPTION
Adds error handling using the "thiserror" library.

The idea is to expose the public errors in limitador/src/errors.rs to users of the library. The rest of errors are internal.